### PR TITLE
fix: cloudinary res secure_url

### DIFF
--- a/app/api/cloudinary/route.ts
+++ b/app/api/cloudinary/route.ts
@@ -17,7 +17,7 @@ export async function POST(req: Request) {
 
     const uploadRes = await cloudinary.uploader.upload(base64Image);
 
-    return NextResponse.json({ url: uploadRes.url });
+    return NextResponse.json({ url: uploadRes.secure_url });
   } catch (error) {
     if (error instanceof Error)
       return NextResponse.json({ message: error.message }, { status: 500 });


### PR DESCRIPTION
used `secure_url` instead `url` which doesn't matches with `next.config.images.remotePatterns`
fixes: `INVALID_IMAGE_OPTIMIZATION_REQUEST` err